### PR TITLE
修复在 debug 模式下同一个 namespace 多个 xml 文件无法正确获取 Fenix 节点的问题

### DIFF
--- a/src/main/java/com/blinkfox/fenix/config/FenixConfig.java
+++ b/src/main/java/com/blinkfox/fenix/config/FenixConfig.java
@@ -66,6 +66,7 @@ import com.blinkfox.fenix.specification.handler.impl.StartsWithPredicateHandler;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import lombok.Getter;
 import org.dom4j.Node;
@@ -127,7 +128,7 @@ public class FenixConfig {
      * @since v2.4.1
      */
     @Getter
-    private static final Map<String, URL> xmlUrlMap = new HashMap<>();
+    private static final Map<String, Set<URL>> xmlUrlMap = new HashMap<>();
 
     /**
      * 初始化默认的一些标签和 TagHandler 实例到 HashMap 集合中，key 是标签字符串,value 是 TagHandler 实例.

--- a/src/main/java/com/blinkfox/fenix/config/FenixConfigManager.java
+++ b/src/main/java/com/blinkfox/fenix/config/FenixConfigManager.java
@@ -13,7 +13,9 @@ import com.blinkfox.fenix.helper.StringHelper;
 import com.blinkfox.fenix.helper.XmlNodeHelper;
 import java.net.URL;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -129,7 +131,7 @@ public final class FenixConfigManager {
 
         // 是否开启了 debug 模式.
         final boolean debug = this.fenixConfig.isDebug();
-        Map<String, URL> xmlUrlMap = FenixConfig.getXmlUrlMap();
+        Map<String, Set<URL>> xmlUrlMap = FenixConfig.getXmlUrlMap();
 
         // 遍历各个 XML 资源文件信息，将 fenixId 和 对应的 Node 节点缓存起来.
         Collection<XmlResource> xmlResources = xmlResourceMap.values();
@@ -153,7 +155,8 @@ public final class FenixConfigManager {
 
                 // v2.4.1 版本新增，如果开启了 debug 模式，就建立 namespace 和 xml 路径的映射关系，便于实时读取 XML 文件中的内容.
                 if (debug) {
-                    xmlUrlMap.put(namespace, xmlResource.getUrl());
+                    Set<URL> urlSet = xmlUrlMap.computeIfAbsent(namespace, k -> new HashSet<>());
+                    urlSet.add(xmlResource.getUrl());
                 }
             }
         }

--- a/src/test/resources/fenix/BlogRepository.xml
+++ b/src/test/resources/fenix/BlogRepository.xml
@@ -2,13 +2,6 @@
 <!-- 这是用来测试 XML 模版或标签生成的 SQL语句或参数的 Fenix XML 文件. -->
 <fenixs namespace="BlogRepository">
 
-    <!-- 一个最简单的示例来查询我的博客信息. -->
-    <fenix id="querySimplyDemo">
-        SELECT b FROM Blog AS b
-        WHERE
-        <equal field="b.id" value="blog.id"/>
-    </fenix>
-
     <!-- 查询我的博客信息2. -->
     <fenix id="queryBlogs2">
         SELECT b FROM Blog AS b

--- a/src/test/resources/fenix/BlogRepository4DebugModel.xml
+++ b/src/test/resources/fenix/BlogRepository4DebugModel.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 这是用来测试 XML 模版或标签生成的 SQL语句或参数的 Fenix XML 文件. -->
+<fenixs namespace="BlogRepository">
+
+    <!-- 一个最简单的示例来查询我的博客信息. -->
+    <fenix id="querySimplyDemo">
+        SELECT b FROM Blog AS b
+        WHERE
+        <equal field="b.id" value="blog.id"/>
+    </fenix>
+
+</fenixs>


### PR DESCRIPTION
未开启 debug 模式下,由于直接存储的是 fenixNode,问题不存在。
但是如果开启了 debug 模式，那么需要通过 URL 实时读取文件解析并获取 fenixNode,而 xmlUrlMap 的 value 为 单个的 URL,那么问题就复现了

主要是保证在开启了 debug 和未开启 debug 模式下的行为一致

测试的话，直接复用了之前的用例，通过在 com.blinkfox.fenix.repository.BlogRepositoryTest#init 方法中添加 myFenixConfig.setDebug(true); 来控制是否开启 debug 模式 并测试。