### PR TITLE
修改了自定义查询结果的转换器以支持简单的嵌套属性

### DIFF
--- a/src/test/java/com/blinkfox/fenix/repository/BlogRepository.java
+++ b/src/test/java/com/blinkfox/fenix/repository/BlogRepository.java
@@ -5,6 +5,7 @@ import com.blinkfox.fenix.jpa.QueryFenix;
 import com.blinkfox.fenix.provider.BlogSqlInfoProvider;
 import com.blinkfox.fenix.vo.UserBlogDto;
 import com.blinkfox.fenix.vo.UserBlogInfo;
+import com.blinkfox.fenix.vo.UserBlogInfo4Nested;
 import com.blinkfox.fenix.vo.UserBlogProjection;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +15,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 
 /**
  * 博客数据的库持久化类.
@@ -95,6 +95,17 @@ public interface BlogRepository extends JpaRepository<Blog, String> {
      */
     @QueryFenix(value = "BlogRepository.queryUserBlogsWithFenixNative", nativeQuery = true)
     List<UserBlogInfo> queryUserBlogsWithFenixNative(@Param("userId") String userId, @Param("title") String title);
+
+    /**
+     * 使用原生的 {@link QueryFenix} 注解来连表模糊查询自定义的用户博客实体信息.主要测试嵌套属性的投影
+     *
+     * @param userId 用户 ID
+     * @param title 标题
+     * @return 用户博客信息集合
+     */
+    @QueryFenix(value = "BlogRepository.queryUserBlogsWithFenixNative4Nested", nativeQuery = true)
+    List<UserBlogInfo4Nested> queryUserBlogsWithFenixNative4Nested(@Param("userId") String userId,
+            @Param("title") String title);
 
     /**
      * 使用 {@link QueryFenix} 注解来连表模糊查询自定义的用户博客实体分页信息.
@@ -221,6 +232,7 @@ public interface BlogRepository extends JpaRepository<Blog, String> {
 
     /**
      * 使用开启 distinct 检测的分页查询.
+     *
      * @param pageable 分页参数{@link Pageable}
      * @return 博客集合
      */
@@ -229,6 +241,7 @@ public interface BlogRepository extends JpaRepository<Blog, String> {
 
     /**
      * 使用开启 distinct 检测但是没有 distinct 关键字的分页查询.
+     *
      * @param pageable 分页参数{@link Pageable}
      * @return 博客集合
      */
@@ -237,6 +250,7 @@ public interface BlogRepository extends JpaRepository<Blog, String> {
 
     /**
      * 使用开启 distinct 检测但是没有 distinct 关键字的原生 sql 分页查询.
+     *
      * @param pageable 分页参数{@link Pageable}
      * @return 博客集合
      */
@@ -245,6 +259,7 @@ public interface BlogRepository extends JpaRepository<Blog, String> {
 
     /**
      * 使用开启 distinct 检测但是没有 distinct 关键字的原生 sql 分页查询.
+     *
      * @param pageable 分页参数{@link Pageable}
      * @return 用户ID集合
      */

--- a/src/test/java/com/blinkfox/fenix/repository/BlogRepositoryTest.java
+++ b/src/test/java/com/blinkfox/fenix/repository/BlogRepositoryTest.java
@@ -11,6 +11,7 @@ import com.blinkfox.fenix.helper.StringHelper;
 import com.blinkfox.fenix.jpa.QueryFenix;
 import com.blinkfox.fenix.vo.UserBlogDto;
 import com.blinkfox.fenix.vo.UserBlogInfo;
+import com.blinkfox.fenix.vo.UserBlogInfo4Nested;
 import com.blinkfox.fenix.vo.UserBlogProjection;
 import java.io.IOException;
 import java.util.Date;
@@ -162,6 +163,17 @@ public class BlogRepositoryTest {
         List<UserBlogInfo> userBlogs = blogRepository.queryUserBlogsWithFenixNative("1", SPRING);
         Assert.assertFalse(userBlogs.isEmpty());
         Assert.assertTrue(StringHelper.isNotBlank(userBlogs.get(0).getName()));
+    }
+
+    /**
+     * 测试嵌套属性投影.
+     */
+    @Test
+    public void testQueryUserBlogsWithFenixNative4Nested() {
+        List<UserBlogInfo4Nested> userBlogInfo4Nesteds = blogRepository.queryUserBlogsWithFenixNative4Nested("1",
+                SPRING);
+        Assert.assertFalse(userBlogInfo4Nesteds.isEmpty());
+        Assert.assertTrue(StringHelper.isNotBlank(userBlogInfo4Nesteds.get(0).getName()));
     }
 
     /**

--- a/src/test/java/com/blinkfox/fenix/vo/DeepNestedUserBlogInfo.java
+++ b/src/test/java/com/blinkfox/fenix/vo/DeepNestedUserBlogInfo.java
@@ -1,0 +1,29 @@
+package com.blinkfox.fenix.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 作为深层嵌套属性进行测试.
+ *
+ * @author hanandjun on 2021-10-22.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeepNestedUserBlogInfo {
+
+    /**
+     * 博客原作者.
+     */
+    private String author;
+
+    /**
+     * 博客内容.
+     */
+    private String content;
+
+}

--- a/src/test/java/com/blinkfox/fenix/vo/NestedUserBlogInfo.java
+++ b/src/test/java/com/blinkfox/fenix/vo/NestedUserBlogInfo.java
@@ -1,0 +1,31 @@
+package com.blinkfox.fenix.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 作为嵌套属性进行测试.
+ *
+ * @author hanandjun on 2021-10-22.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NestedUserBlogInfo {
+
+    /**
+     * 博客原作者.
+     */
+    private String author;
+
+    /**
+     * 博客内容.
+     */
+    private String content;
+
+    private DeepNestedUserBlogInfo deepNestedUserBlogInfo;
+
+}

--- a/src/test/java/com/blinkfox/fenix/vo/UserBlogInfo4Nested.java
+++ b/src/test/java/com/blinkfox/fenix/vo/UserBlogInfo4Nested.java
@@ -1,0 +1,51 @@
+package com.blinkfox.fenix.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 用户博客信息的自定义业务实体类，用于测试 JPA 返回自定义实体中嵌套属性的使用.
+ *
+ * @author hanandjun on 2021-10-22.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserBlogInfo4Nested {
+
+    /**
+     * 用户 ID.
+     */
+    private String userId;
+
+    /**
+     * 用户名称.
+     */
+    private String name;
+
+    /**
+     * 用户博客 ID.
+     */
+    private String blogId;
+
+    /**
+     * 博客标题.
+     */
+    private String title;
+
+    /**
+     * 博客原作者.
+     */
+    private String author;
+
+    /**
+     * 博客内容.
+     */
+    private String content;
+
+    private NestedUserBlogInfo nestedUserBlogInfo;
+
+}

--- a/src/test/resources/fenix/BlogRepository.xml
+++ b/src/test/resources/fenix/BlogRepository.xml
@@ -71,18 +71,39 @@
     <!-- 根据用户ID、博客信息查询该用户发表的用户博客信息（用于测试返回自定义的实体信息）. -->
     <fenix id="queryUserBlogsWithFenixNative" resultType="com.blinkfox.fenix.vo.UserBlogInfo">
         SELECT
-            u.c_id as userId,
-            u.c_name as name,
-            b.c_id as blogId,
-            b.c_title as title,
-            b.c_author as author,
-            b.c_content as content
+            u.c_id as "userId",
+            u.c_name as "name",
+            b.c_id as "blogId",
+            b.c_title as "title",
+            b.c_author as "author",
+            b.c_content as "content"
         FROM
             t_blog as b, t_user as u
         WHERE
             u.c_id = b.c_user_id
         AND b.c_user_id = #{userId}
         AND b.c_title LIKE #{title}
+    </fenix>
+
+    <!-- 根据用户ID、博客信息查询该用户发表的用户博客信息（用于测试返回自定义的实体的嵌套属性信息）. -->
+    <fenix id="queryUserBlogsWithFenixNative4Nested" resultType="com.blinkfox.fenix.vo.UserBlogInfo4Nested">
+        SELECT
+            u.c_id as "userId",
+            u.c_name as "name",
+            b.c_id as "blogId",
+            b.c_title as "title",
+            b.c_author as "author",
+            b.c_author as "nestedUserBlogInfo.author",
+            b.c_author as "nestedUserBlogInfo.deepNestedUserBlogInfo.author",
+            b.c_content as "content",
+            b.c_content as "nestedUserBlogInfo.content",
+            b.c_content as "nestedUserBlogInfo.deepNestedUserBlogInfo.content"
+        FROM
+            t_blog as b, t_user as u
+        WHERE
+            u.c_id = b.c_user_id
+          AND b.c_user_id = #{userId}
+          AND b.c_title LIKE #{title}
     </fenix>
 
     <!-- 根据用户ID、博客信息查询该用户发表的用户博客信息（用于测试返回自定义的实体信息）. -->


### PR DESCRIPTION
目前仅仅‘逆向’了解下转换逻辑，意识到或许可以通过 org.springframework.beans.PropertyAccessor#setPropertyValue(java.lang.String, java.lang.Object) 来进行嵌套属性的处理。

更改内容中仅仅针对 a.b.c 类型的简单的嵌套属性做了处理，对 List 或者 Array 之类的还没有支持。另外，根据 [hsqldb 的描述](http://www.hsqldb.org/doc/1.8/guide/guide.html#expression-section)，在 native sql 的情况中 aliases 的名称为全部大写，所以暂时使用了双引号做了规避，这里也是一个 break point。

项目中新增了一个嵌套属性的测试，并且通过了其他的测试方法。
